### PR TITLE
fixed decision table function copied from r4ss

### DIFF
--- a/Rcode/decision_table.R
+++ b/Rcode/decision_table.R
@@ -1,30 +1,30 @@
-SS_decision_table_stuff <- function(replist, yrs = 2025:2036, digits = c(0, 0, 3)) {
-  # needs to be able to aggregate across areas for spatial models
-  if (replist[["N_areas"]] > 1) {
-    warning("You probably need to aggregate function output across areas")
-  }
-  # subset timeseries
-  ts <- replist[["timeseries"]][replist[["timeseries"]][["Yr"]] %in% yrs, ]
-  # note that new $dead_B_sum quantity can be used in future versions
-  catch <- round(
-    apply(ts[, grep("dead(B)", names(ts), fixed = TRUE)],
-          MARGIN = 1, FUN = sum
-    ),
-    digits[1]
-  )
-  yr <- ts[["Yr"]]
-  # get spawning biomass
-  SpawnBio <- round(ts[["SpawnBio"]], digits[2])
-  # get depletion (this calc is independent of Bratio definition)
-  SpawnBioVirg <-
-    replist[["timeseries"]][["SpawnBio"]][replist[["timeseries"]][["Era"]] == "VIRG"]
-  dep <- round(SpawnBio / SpawnBioVirg, digits[3])
-  # get summary biomass (not currently reported)
-  Bio_smry <- ts[["Bio_smry"]]
-  # combine stuff
-  # stuff <- data.frame(yr=yr[ts[["Area"]]==1], catch, dep, SpawnBio, Bio_smry)
-  stuff <- data.frame(yr, catch, SpawnBio, dep)
-  return(stuff)
+#' function modiifed from r4ss::SS_decision_table_stuff
+#' to aggregate across areas and modernize to dplyr
+SS_decision_table_stuff2 <- function(replist, yrs = 2025:2036, digits = c(0, 0, 3)) {
+  unfished <- replist[["derived_quants"]]["SSB_Virgin", "Value"]
+  replist[["timeseries"]] |>
+    dplyr::filter(Yr %in% yrs) |>
+    dplyr::group_by(Yr) |>
+    dplyr::summarise(
+      catch = sum(rowSums(dplyr::across(dplyr::starts_with("dead(B)")), na.rm = TRUE)),
+      spawn_bio = sum(SpawnBio, na.rm = TRUE)
+    ) |>
+    dplyr::mutate(
+      # calculation of fraction_unfished is independent of Bratio definition
+      # which could have a different denominator
+      fraction_unfished = spawn_bio / unfished
+    ) |>
+    dplyr::mutate(
+      catch = round(catch, digits[1]),
+      spawn_bio = round(spawn_bio, digits[2]),
+      fraction_unfished = round(fraction_unfished, digits[3])
+    ) |>
+    dplyr::rename(
+      # matching names in earlier version of the function for backwards compatibility
+      yr = Yr,
+      SpawnBio = spawn_bio,
+      dep = fraction_unfished
+    )
 }
 
 
@@ -80,7 +80,7 @@ table_decision <- function(
   results <- purrr::modify_depth(
     mods,
     .depth = 2,
-    .f = SS_decision_table_stuff,
+    .f = SS_decision_table_stuff2,
     yrs = years,
     digits = digits
   ) |>

--- a/Rcode/table_sens.R
+++ b/Rcode/table_sens.R
@@ -71,7 +71,7 @@ table_clean_labels <- function(tab) {
   # not generalized, depends on fecundity parameters and summary biomass age
   newlabel <- gsub("SmryBio unfished", "Unfished age 4+ bio 1000 mt", newlabel)
   # newlabel <- gsub("thousand", "1000", newlabel)
-  newlabel <- gsub("B(\\d+)", "B\\1 trillions of eggs", newlabel) # should work for B0 and B2025
+  newlabel <- gsub("B(\\d+)", "B\\1 millions of eggs", newlabel) # should work for B0 and B2025
   tab$Label <- newlabel
   return(tab)
 }

--- a/report/002_load_tables.qmd
+++ b/report/002_load_tables.qmd
@@ -226,13 +226,13 @@ catch_table_est_weights <- inputs$dat$catch |>
 #| echo: false
 #| eval: true
 
-decision_table_cap <- "Decision table with 10-year projections. 'Mgmt' refers to the three management scenarios (A) the default harvest control rule $P^* = 0.45$, (B) harvest control rule with a lower $P^* = 0.40$. In each case the 2023 and 2024 catches are fixed at the ACLs which have been set for that year with estimated fleet allocation provided  by the GMT. The alternative states of nature ('Low', 'Base', and 'High' as discussed in the text) are provided in the columns, with Spawning Output ('Spawn', in trillions of eggs) and Fraction of unfished spawning output ('Frac') provided for each state."
+decision_table_cap <- "Decision table with 10-year projections. 'Mgmt' refers to the three management scenarios (A) the default harvest control rule $P^* = 0.45$, (B) harvest control rule with a lower $P^* = 0.40$. In each case the 2025 and 2026 catches are fixed at the ACLs which have been set for that year with estimated fleet allocation provided by the GMT. The alternative states of nature ('Low', 'Base', and 'High' as discussed in the text) are provided in the columns, with Spawning Output ('Spawn', in millions of eggs) and Fraction of unfished spawning output ('Frac') provided for each state."
 
 # # replace mod_out below with calls like
 # mod_low_A <- SS_output(dir_low_A,
 #     verbose = FALSE,
 #     printstats = FALSE,
-#     SpawnOutputLabel = "Spawning Output (trillions of eggs)"
+#     SpawnOutputLabel = "Spawning Output (millions of eggs)"
 # )
 
 mod_low_A <- replist


### PR DESCRIPTION
@rclairer, following up on email conversation about issue with `r4ss::SS_decision_table_stuff()`, here's a fix for your repository which will save you having to wait for r4ss changes or reinstall that package. I have tested on your model, but not in the rendered document.

Note that the full set of models for the decision table still needs to be added in https://github.com/rclairer/Sebastes_ruberrimus_2025/blob/main/report/002_load_tables.qmd#L231-L248

Changes:
- now aggregates decision table values across areas
- also update years and units (trillions to millions) in the decision table caption (assuming that millions is correct based on other instances throughout the report)
- change to `table_sens()` is to also remove "trillions" leftover from yellowtail